### PR TITLE
关于web有可能无法打开图片的问题

### DIFF
--- a/src/main/resources/js/chat-room.js
+++ b/src/main/resources/js/chat-room.js
@@ -2130,6 +2130,8 @@ ${result.info.msg}
                     $fn.removeClass("fn-none");
 
                     $stacked.fadeIn(200);
+                    // 防止图片无法正常打开
+                    ChatRoom.imageViewer()
                 }, 100);
             } else {
                 $('#plusOne').remove();


### PR DESCRIPTION
BUG触发条件是，当有人复读图片如果没有新的消息传输，会导致图片无法打开大图

---

我在`堆叠复读机消息`这个方法处理内部发现有个延迟器。 我猜测是这个`ChatRoom.imageViewer()`方法在这个延迟器触发之前执行的，导致这个延迟器后执行，覆盖掉了`imgViewer`之前的操作。

我只修改了`chat-room.js`，并未修改`chat-room.min.js`(实际上这个似乎得编译）