### PR TITLE
fix(Chatroom): 修复音乐消息title未作标签剔除处理

### DIFF
--- a/src/main/java/org/b3log/symphony/processor/ChatroomProcessor.java
+++ b/src/main/java/org/b3log/symphony/processor/ChatroomProcessor.java
@@ -1171,6 +1171,11 @@ public class ChatroomProcessor {
                 String musicString = content.replaceAll("^\\[music\\]", "").replaceAll("\\[/music\\]$", "");
                 JSONObject music = new JSONObject(musicString);
                 music.put("msgType","music");
+                String title = music.getString("title");
+                if (title != null) {
+                    // 将HTML标签全部替换为空
+                    music.put("title", title.replaceAll("<[^>]*>", ""));
+                }
                 // 加活跃
                 incLiveness(userId);
                 // 聊天室内容保存到数据库


### PR DESCRIPTION
修复音乐消息title未作标签剔除处理，音乐卡片标题可以放<script>标签执行js代码

<img width="1156" height="259" alt="image" src="https://github.com/user-attachments/assets/8575e373-8e3b-4220-8aef-6ff39ed2ad21" />
